### PR TITLE
Fix Permission check in isWritable

### DIFF
--- a/src/tkgate/tkgate_config.h
+++ b/src/tkgate/tkgate_config.h
@@ -40,6 +40,7 @@
 #define TKGATE_STUBLEN	15		/* Default length of wires on new gates */
 #define MAXMODS		128		/* Maximum number of modules in text buffer */
 #define MODULE_PATH_MAX	2048		/* Maximum module depth */
+#define GRPMAX 64                       /* Size of list when calling getgroups */
 
 
 /*


### PR DESCRIPTION
This function analysed the permissions of a file or directory that is
going to be written. However it gave the wrong answer when the file or
directory was not owned by de user and the group of the file was not the
main group of the user. In the following example user is allowed to
write in /media/sf_tmp/hhh because they belong to the vboxsf group, and
tkgate complained that it had no permissions.

user@somehost:/media/sf_tmp$ ls
drwxrwx---  2 root    vboxsf 4096 nov  6 16:04 test
user@somehost:/media/sf_tmp$ groups
user vboxsf

The example is a common situation when using tkgate in a virtual machine
and attempting to write on a shared folder.

The fix includes a call to getgropus and iterates through the list
before deciding the user can not write in the directory or file.